### PR TITLE
headIdx Reformat

### DIFF
--- a/qine/assets/data/enemies/avatar/qine.json
+++ b/qine/assets/data/enemies/avatar/qine.json
@@ -54,7 +54,7 @@
   "healDropRate": 0,
   "boss": false,
   "bossOrder": 0,
-  "headIdx": 3,
+  "headIdx": "qine",
   "padding": {
     "x": 2,
     "y": 2

--- a/qine/assets/data/players/headIdx.json.patch
+++ b/qine/assets/data/players/headIdx.json.patch
@@ -5,6 +5,7 @@
 	"type": "ADD_ARRAY_ELEMENT",
 	"content": {
 		"id": "mod.qine",
-		"img" : "media/gui/severed-heads/qine.png"
+		"img" : "media/gui/severed-heads/qine.png",
+		"name" : "qine"
 	}
 }]

--- a/qine/package.json
+++ b/qine/package.json
@@ -7,6 +7,6 @@
   "ccmodDependencies": {
     "ccloader": "^2.14.1",
     "hardcoded-config-injector": "^0.1.0",
-    "extendable-severed-heads": "^1.0.0"
+    "extendable-severed-heads": "^1.1.0"
   }
 }


### PR DESCRIPTION
Updated headIdx format for extendable-severed-heads 1.1.0, which allows this value to be defined as a string. This fixes conflicts with other mods.